### PR TITLE
Got posts working correctly on profiles

### DIFF
--- a/api/postData.js
+++ b/api/postData.js
@@ -2,8 +2,8 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
-const getAllPosts = (uid) => new Promise((resolve, reject) => {
-  fetch(`${endpoint}/posts.json?orderBy="uid"&equalTo="${uid}"`, {
+const getAllPosts = () => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts.json`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/components/cards/PostCard.js
+++ b/components/cards/PostCard.js
@@ -21,6 +21,7 @@ export default function PostCard({ postObj }) {
           <ListGroup>
             {isCurrentUserProfile && (<><Button variant="danger" onClick={deletePostPrompt}>Delete Post</Button><a href={`/post/update/${postObj.firebaseKey}`}><Button variant="info"> Edit Profile </Button></a></>)}
           </ListGroup>
+          {isCurrentUserProfile && postObj.public === false && (<ListGroup>Private Post</ListGroup>)}
         </Card.Body>
       </Card>
     </div>
@@ -33,5 +34,6 @@ PostCard.propTypes = {
     postImg: PropTypes.string,
     title: PropTypes.string,
     uid: PropTypes.string,
+    public: PropTypes.bool,
   }).isRequired,
 };

--- a/pages/profile/[firebaseKey].js
+++ b/pages/profile/[firebaseKey].js
@@ -18,7 +18,10 @@ export default function ViewProfile() {
     getSingleProfile(firebaseKey).then(setProfileDetails);
   };
   const getPosts = () => {
-    getAllPosts(user.uid).then(setPosts);
+    getAllPosts().then((allPosts) => {
+      const profilePosts = Object.values(allPosts).filter((post) => post.profileId === firebaseKey && (isCurrentUserProfile || post.public === true));
+      setPosts(profilePosts);
+    });
   };
 
   useEffect(() => {


### PR DESCRIPTION
## Description
Originally the profile pages were all rendering the same posts because I had them being pulled by uid instead of matching the profileId of the posts to the firebaseKey of the profiles. Additionally, I was pulling both public and private posts for everyone. Now, only the user who created the profile will see all posts, and other users will only see public posts.

## Related Issue
#8 

## Motivation and Context
All profiles should display only public posts of the profile that created them to users that aren't the profile creator.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
