### PR TITLE
Really, actually fixed it this time

### DIFF
--- a/api/postData.js
+++ b/api/postData.js
@@ -2,8 +2,8 @@ import { clientCredentials } from '../utils/client';
 
 const endpoint = clientCredentials.databaseURL;
 
-const getAllPosts = () => new Promise((resolve, reject) => {
-  fetch(`${endpoint}/posts.json`, {
+const getAllPostsByProfile = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts.json?orderBy="profileId"&equalTo="${firebaseKey}"`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -16,6 +16,21 @@ const getAllPosts = () => new Promise((resolve, reject) => {
       } else {
         resolve([]);
       }
+    })
+    .catch(reject);
+});
+
+const getPublicPostsByProfile = (firebaseKey) => new Promise((resolve, reject) => {
+  fetch(`${endpoint}/posts.json?orderBy="profileId"&equalTo="${firebaseKey}"`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      const filteredPosts = Object.values(data).filter((post) => post.private === false);
+      resolve(filteredPosts);
     })
     .catch(reject);
 });
@@ -68,5 +83,5 @@ const updatePost = (payload) => new Promise((resolve, reject) => {
 });
 
 export {
-  getAllPosts, getSinglePost, updatePost, deletePost, createPost,
+  getAllPostsByProfile, getSinglePost, updatePost, deletePost, createPost, getPublicPostsByProfile,
 };

--- a/components/cards/PostCard.js
+++ b/components/cards/PostCard.js
@@ -1,16 +1,19 @@
 import { Button, Card, ListGroup } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import { useAuth } from '../../utils/context/authContext';
-import { deletePost, getAllPosts } from '../../api/postData';
+import { deletePost } from '../../api/postData';
 
-export default function PostCard({ postObj }) {
+// ... (imports)
+
+export default function PostCard({ postObj, onUpdate }) {
   const deletePostPrompt = () => {
     if (window.confirm('Are you sure you want to delete this post?')) {
-      deletePost(postObj.firebaseKey).then(getAllPosts);
+      deletePost(postObj.firebaseKey).then(onUpdate);
     }
   };
   const { user } = useAuth();
   const isCurrentUserProfile = user.uid === postObj.uid;
+  console.warn(isCurrentUserProfile);
 
   return (
     <div id="post-card-container">
@@ -19,9 +22,23 @@ export default function PostCard({ postObj }) {
         <Card.Body>
           <Card.Img id="post-img" src={postObj.postImg} />
           <ListGroup>
-            {isCurrentUserProfile && (<><Button variant="danger" onClick={deletePostPrompt}>Delete Post</Button><a href={`/post/update/${postObj.firebaseKey}`}><Button variant="info"> Edit Profile </Button></a></>)}
+            {isCurrentUserProfile && (
+              <>
+                <Button variant="danger" onClick={deletePostPrompt}>
+                  Delete Post
+                </Button>
+                <a href={`/post/update/${postObj.firebaseKey}`}>
+                  <Button variant="info"> Edit Post </Button>
+                </a>
+              </>
+            )}
           </ListGroup>
-          {isCurrentUserProfile && postObj.public === false && (<ListGroup>Private Post</ListGroup>)}
+          {isCurrentUserProfile && postObj.private && (
+            <ListGroup>Private Post</ListGroup>
+          )}
+          {!isCurrentUserProfile && postObj.private && (
+            <ListGroup>Private Post</ListGroup>
+          )}
         </Card.Body>
       </Card>
     </div>
@@ -34,6 +51,7 @@ PostCard.propTypes = {
     postImg: PropTypes.string,
     title: PropTypes.string,
     uid: PropTypes.string,
-    public: PropTypes.bool,
+    private: PropTypes.bool,
   }).isRequired,
+  onUpdate: PropTypes.func.isRequired,
 };

--- a/components/forms/CreatePostForm.js
+++ b/components/forms/CreatePostForm.js
@@ -1,7 +1,120 @@
-// const initialState = {
-//   title: '',
-//   postImg: '',
-//   public: '',
-// };
+import { useRouter } from 'next/router';
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+import { Button, FloatingLabel, Form } from 'react-bootstrap';
+import { useAuth } from '../../utils/context/authContext';
+import { createPost, updatePost } from '../../api/postData';
+import { getSingleProfile } from '../../api/profileData';
 
-// export
+const initialState = {
+  title: '',
+  postImg: '',
+  private: false,
+};
+
+export default function CreatePostForm({ obj }) {
+  const [formInput, setFormInput] = useState(initialState);
+  const [profileDetails, setProfileDetails] = useState({});
+  const router = useRouter();
+  const { user } = useAuth();
+
+  useEffect(() => {
+    if (obj.firebaseKey) setFormInput(obj);
+    getSingleProfile(obj.firebaseKey).then(setProfileDetails);
+    console.warn(profileDetails);
+  }, [obj, user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormInput((prevState) => ({
+      ...prevState,
+      [name]: value,
+    }));
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const payload = {
+      ...formInput,
+      uid: user.uid,
+      profileId: obj.firebaseKey,
+    };
+    if (obj.firebaseKey) {
+      updatePost(formInput).then(() => router.push(`/profile/${obj.firebaseKey}`));
+    } else {
+      createPost(payload).then(({ name }) => {
+        const patchPayload = { firebaseKey: name };
+        updatePost(patchPayload).then(() => {
+          router.push(`/profile/${obj.firebaseKey}`);
+        });
+      });
+    }
+  };
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <h2 className="text-white mt-5">
+        {obj.firebaseKey ? 'Update' : 'Create'} Post
+      </h2>
+      <FloatingLabel
+        controlId="floatingInput1"
+        label="Title of Post"
+        className="mb-3"
+      >
+        <Form.Control
+          type="text"
+          placeholder="Enter Post Title"
+          name="title"
+          value={formInput.title}
+          onChange={handleChange}
+          required
+        />
+      </FloatingLabel>
+      <FloatingLabel
+        controlId="floatingInput2"
+        label="Post Image URL"
+        className="mb-3"
+      >
+        <Form.Control
+          type="url"
+          placeholder="Enter Image URL"
+          name="postImg"
+          value={formInput.postImg}
+          onChange={handleChange}
+          required
+        />
+      </FloatingLabel>
+      <Form.Check
+        className="text-white mb-3"
+        type="switch"
+        id="private"
+        name="private"
+        label="Private Post?"
+        checked={formInput.private}
+        onChange={(e) => {
+          setFormInput((prevState) => ({
+            ...prevState,
+            private: e.target.checked,
+          }));
+        }}
+      />
+      <Button type="submit">
+        {obj.firebaseKey ? 'Update' : 'Create'} Post
+      </Button>
+    </Form>
+  );
+}
+
+CreatePostForm.propTypes = {
+  obj: PropTypes.shape({
+    title: PropTypes.string,
+    postImg: PropTypes.string,
+    sale: PropTypes.bool,
+    profileId: PropTypes.string,
+    firebaseKey: PropTypes.string,
+  }),
+};
+
+CreatePostForm.defaultProps = {
+  obj: initialState,
+};

--- a/pages/posts/new.js
+++ b/pages/posts/new.js
@@ -1,0 +1,5 @@
+import CreatePostForm from '../../components/forms/CreatePostForm';
+
+export default function CreateProfile() {
+  return <CreatePostForm />;
+}

--- a/pages/profile/[firebaseKey].js
+++ b/pages/profile/[firebaseKey].js
@@ -2,9 +2,10 @@
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { Button } from 'react-bootstrap';
+import Link from 'next/link';
 import { deleteProfile, getAllProfiles, getSingleProfile } from '../../api/profileData';
 import { useAuth } from '../../utils/context/authContext';
-import { getAllPosts } from '../../api/postData';
+import { getAllPostsByProfile, getPublicPostsByProfile } from '../../api/postData';
 import PostCard from '../../components/cards/PostCard';
 
 export default function ViewProfile() {
@@ -13,24 +14,22 @@ export default function ViewProfile() {
   const router = useRouter();
   const { firebaseKey } = router.query;
   const { user } = useAuth();
-  const isCurrentUserProfile = user.uid === profileDetails.uid;
+  const isCurrentUserProfile = user?.uid === profileDetails.uid;
   const getProfile = () => {
     getSingleProfile(firebaseKey).then(setProfileDetails);
   };
   const getPosts = () => {
-    getAllPosts().then((allPosts) => {
-      const profilePosts = Object.values(allPosts).filter((post) => post.profileId === firebaseKey && (isCurrentUserProfile || post.public === true));
-      setPosts(profilePosts);
-    });
+    if (isCurrentUserProfile) {
+      getAllPostsByProfile(firebaseKey).then(setPosts);
+    } else {
+      getPublicPostsByProfile(firebaseKey).then(setPosts);
+    }
   };
 
   useEffect(() => {
     getProfile();
-  }, []);
-
-  useEffect(() => {
     getPosts();
-  }, []);
+  }, [profileDetails.uid, profileDetails.uid]);
 
   const deleteProfilePrompt = () => {
     if (window.confirm('Delete Your Profile?')) {
@@ -38,6 +37,53 @@ export default function ViewProfile() {
     }
   };
 
+  if (isCurrentUserProfile) {
+    return (
+      <div>
+        <div className="mt-5 d-flex flex-wrap">
+          <div className="d-flex flex-column">
+            <img src={profileDetails.image} alt={profileDetails.title} style={{ width: '300px' }} />
+          </div>
+          <div className="text-white ms-5 details">
+            <h1>{profileDetails?.name}</h1>
+            <h5>
+              <ul>Specialty Style: {profileDetails.style}</ul>
+              <ul>Typical Rates: {profileDetails.rates}</ul>
+              <ul>Years of Experience {profileDetails.experience}</ul>
+            </h5>
+            <ul>
+              About Me:
+              <br />
+              {profileDetails.bio}
+            </ul>
+            <ul>
+              <a href={`mailto:${profileDetails.email}`}>
+                <Button variant="info">Contact Me For Commissions</Button>
+              </a>
+            </ul>
+            <ul>
+              <Button variant="danger" onClick={deleteProfilePrompt}> Delete Profile </Button> <a href={`/profile/update-profile/${profileDetails.firebaseKey}`}><Button variant="info"> Edit Profile </Button></a>
+            </ul>
+            <br />
+          </div>
+        </div>
+        <hr
+          style={{
+            backgroundColor: 'black',
+            color: 'black',
+            borderColor: 'black',
+            height: '2px',
+          }}
+        />
+        <div id="post-container">
+          <Link passHref a href="/posts/new"><Button variant="primary">Create Post</Button></Link>
+          {posts.map((post) => (
+            <PostCard key={post.firebaseKey} postObj={post} onUpdate={getPosts} />
+          ))}
+        </div>
+      </div>
+    );
+  }
   return (
     <div>
       <div className="mt-5 d-flex flex-wrap">
@@ -61,7 +107,6 @@ export default function ViewProfile() {
               <Button variant="info">Contact Me For Commissions</Button>
             </a>
           </ul>
-          <ul> {isCurrentUserProfile && (<><Button variant="danger" onClick={deleteProfilePrompt}> Delete Profile </Button> <a href={`/profile/update-profile/${profileDetails.firebaseKey}`}><Button variant="info"> Edit Profile </Button></a></>)} </ul>
           <br />
         </div>
       </div>

--- a/utils/sample-data/post-data.json
+++ b/utils/sample-data/post-data.json
@@ -4,7 +4,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "War on Democracy, The",
     "postImg": "http://dummyimage.com/231x100.png/ff4444/ffffff",
-    "public": true,
+    "private": false,
     "profileId": "337063866-5"
   },
   "462620223-3": {
@@ -12,7 +12,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Simple Wish, A",
     "postImg": "http://dummyimage.com/128x100.png/5fa2dd/ffffff",
-    "public": false,
+    "private": true,
     "profileId": "337063866-5"
   },
   "262530132-5": {
@@ -20,7 +20,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Quitting (Zuotian)",
     "postImg": "http://dummyimage.com/223x100.png/dddddd/000000",
-    "public": true,
+    "private": false,
     "profileId": "337063866-5"
   },
   "930014048-5":{
@@ -28,7 +28,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Three Days of the Condor (3 Days of the Condor)",
     "postImg": "http://dummyimage.com/175x100.png/cc0000/ffffff",
-    "public": true,
+    "private": false,
     "profileId": "075116372-4"
   },
   "228314482-5":{
@@ -36,7 +36,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Business, The",
     "postImg": "http://dummyimage.com/127x100.png/ff4444/ffffff",
-    "public": true,
+    "private": false,
     "profileId": "075116372-4"
   },
   "395728179-2":{
@@ -44,7 +44,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Drona",
     "postImg": "http://dummyimage.com/183x100.png/cc0000/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "075116372-4"
   },
   "397116891-4":{
@@ -52,7 +52,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Family Friend, The (L'amico di famiglia)",
     "postImg": "http://dummyimage.com/112x100.png/dddddd/000000",
-    "public": false,
+    "private": false,
     "profileId": "393465120-8"
   },
   "491149201-5":{
@@ -60,7 +60,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Nina Takes a Lover",
     "postImg": "http://dummyimage.com/149x100.png/5fa2dd/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "393465120-8"
   },
   "096486222-0":{
@@ -68,7 +68,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Fantastic Planet, The (Planète sauvage, La)",
     "postImg": "http://dummyimage.com/178x100.png/dddddd/000000",
-    "public": true,
+    "private": false,
     "profileId": "393465120-8"
   },
   "286081829-4":{
@@ -76,7 +76,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Rånarna",
     "postImg": "http://dummyimage.com/103x100.png/dddddd/000000",
-    "public": false,
+    "private": false,
     "profileId": "393465120-8"
   },
   "497367396-X":{
@@ -84,7 +84,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Faculty, The",
     "postImg": "http://dummyimage.com/232x100.png/cc0000/ffffff",
-    "public": true,
+    "private": false,
     "profileId": "095636089-0"
   },
   "555626986-6":{
@@ -92,7 +92,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Mutiny on the Bounty",
     "postImg": "http://dummyimage.com/153x100.png/5fa2dd/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "095636089-0"
   },
   "164670055-4":{
@@ -100,7 +100,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "House of Strangers",
     "postImg": "http://dummyimage.com/136x100.png/dddddd/000000",
-    "public": true,
+    "private": false,
     "profileId": "095636089-0"
   },
   "592729819-2":{
@@ -108,7 +108,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Reservation Road",
     "postImg": "http://dummyimage.com/131x100.png/ff4444/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "161295383-2"
   },
   "258536775-4":{
@@ -116,7 +116,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Thick as Thieves (a.k.a. Code, The)",
     "postImg": "http://dummyimage.com/150x100.png/5fa2dd/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "161295383-2"
   },
   "332797927-8":{
@@ -124,7 +124,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Red Badge of Courage, The",
     "postImg": "http://dummyimage.com/158x100.png/ff4444/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "161295383-2"
   },
   "065486609-0":{
@@ -132,7 +132,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Wonderful, Horrible Life of Leni Riefenstahl, The (Macht der Bilder: Leni Riefenstahl, Die)",
     "postImg": "http://dummyimage.com/173x100.png/ff4444/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "500544520-X"
   },
   "499278899-8":{
@@ -140,7 +140,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Knick Knack",
     "postImg": "http://dummyimage.com/198x100.png/ff4444/ffffff",
-    "public": true,
+    "private": false,
     "profileId": "500544520-X"
   },
   "608304508-8":{
@@ -148,7 +148,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "Possession of David O'Reilly, The ",
     "postImg": "http://dummyimage.com/130x100.png/cc0000/ffffff",
-    "public": false,
+    "private": false,
     "profileId": "500544520-X"
   },
   "235567812-X":{
@@ -156,7 +156,7 @@
     "uid": "4Oqdg8mfh7TS8iz6zPCAu22GLGr1",
     "title": "West of Zanzibar",
     "postImg": "http://dummyimage.com/178x100.png/dddddd/000000",
-    "public": false,
+    "private": false,
     "profileId": "500544520-X"
   }
 }


### PR DESCRIPTION
Was having an issue where the page would sometimes show both public and private posts to users that didn't create the profile. Was originally declaring two different variables for public and private posts, then calling them in separated return if/else statements. The fix was instead creating one variable for both types of post with an if/else statement, then calling the one variable in both return if/else statements.

## Related Issue
#8 

## Motivation and Context
Profile pages were displaying public and private posts to users that didn't create the profile in question, and this isn't desired.

## How Can This Be Tested?
Can be tested by viewing a profile you didn't create and seeing if you see any private posts, then looking at a profile you created to see if you can see your private posts.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
