### PR TITLE
Fixed error with deleteProfileAndPosts import

### DIFF
--- a/components/cards/ProfileCard.js
+++ b/components/cards/ProfileCard.js
@@ -2,7 +2,7 @@ import { Button, Card, ListGroup } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import { useAuth } from '../../utils/context/authContext';
-import deleteProfileAndPosts from '../../api/mergedData';
+import { deleteProfileAndPosts } from '../../api/mergedData';
 
 export default function ProfileCard({ profileObj, onUpdate }) {
   const deleteProfilePrompt = () => {

--- a/components/cards/ProfileViewCard.js
+++ b/components/cards/ProfileViewCard.js
@@ -2,8 +2,8 @@
 import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { useRouter } from 'next/router';
-import deleteProfileAndPosts from '../../api/mergedData';
 import { useAuth } from '../../utils/context/authContext';
+import { deleteProfileAndPosts } from '../../api/mergedData';
 
 export default function ProfileViewCard({ profileObj }) {
   const router = useRouter();


### PR DESCRIPTION
## Description
Had to re-import deleteProfileAndPosts promise on ProfileViewCard and ViewProfileCard, they stopped working for no discernable reason

## Related Issue
Fix

## Motivation and Context
Delete profile wasn't working

## How Can This Be Tested?
Can be tested by deleting your profile from any page that allows it

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
